### PR TITLE
Corrected response from null to returning an empty array

### DIFF
--- a/app/controllers/postcodes_controller.js
+++ b/app/controllers/postcodes_controller.js
@@ -310,7 +310,7 @@ var nearestPostcodes = function (request, response, next) {
 		if (!results) {
 			response.jsonApiResponse = {
 				status: 200,
-				result: null
+				result: []
 			};
 			return next();
 		} else {


### PR DESCRIPTION
For the latlon route, if no postcodes are found, an empty array should be returned rather than null.