### PR TITLE
Current regex can't detect post codes like SK1 , M1 or any postcode with only 1 digit in the first part.

### DIFF
--- a/public/js/mapbox.js
+++ b/public/js/mapbox.js
@@ -33,7 +33,7 @@ $(function () {
 		.fail(error);
 	}
 
-	var simplePostcodeRegex = /^[a-z0-9]{1,4}\s*?\d[a-z]{2}$/i;
+	var simplePostcodeRegex = /(^[A-Z]{1,2}[0-9R][0-9A-Z]?[\s]?[0-9][ABD-HJLNP-UW-Z]{2}$)/i;
 
 	var queryCache = {};
 


### PR DESCRIPTION
When using auto complete a partial post code, results for M1 , SK1, L1 or any other post code with only 1 digit in first part of the post code is not correct, right now the return values for SK1 is SK10 which is not right. even worse when using SK1 2 instead of getting SK1 2AA / SK1 2AB / ... we get SK12 1AA / SK12 1AA and ...