### PR TITLE
Fix documentation page for bulk reverse geocoding

### DIFF
--- a/app/views/pages/documentation.jade
+++ b/app/views/pages/documentation.jade
@@ -237,9 +237,9 @@ block content
 							.http-method GET 
 							| https://api.postcodes.io/postcodes/lon/:longitude/lat/:latitude
 
-					h3#Bulk-Geocode-Postcode Outcode Reverse Geocoding
+					h3#Bulk-Geocode-Postcode Bulk Reverse Geocoding
 
-					p Bulk translates into geolocations into Postcodes. Accepts up to 100 geolocations.
+					p Bulk translates geolocations into Postcodes. Accepts up to 100 geolocations.
 
 					pre
 						h4 


### PR DESCRIPTION
The title presented it as "Outcode Reverse Geocoding", which is a different endpoint described later in the page.

Also removes an erroneous "into" from the description.