### PR TITLE
Order by postcode if distances are equal

### DIFF
--- a/app/models/postcode.js
+++ b/app/models/postcode.js
@@ -281,7 +281,7 @@ var nearestPostcodeQuery =  ["SELECT postcodes.*,",
 	"FROM postcodes",
 	toJoinString(),
 	"WHERE ST_DWithin(location, ST_GeographyFromText('POINT(' || $1 || ' ' || $2 || ')'), $3)", 
-	"ORDER BY distance",
+	"ORDER BY distance ASC, postcode ASC",
 	"LIMIT $4"].join(" ");
 
 Postcode.prototype.nearestPostcodes = function (params, callback) {


### PR DESCRIPTION
Explicitly sort on postcode if nearest matches share the same geolocation

Should fix #70