### PR TITLE
Fix logger config in production

### DIFF
--- a/config/config.js
+++ b/config/config.js
@@ -86,7 +86,7 @@ const config = {
 		log : {
 			name : "postcodes.io",
 			streams: [{
-				path : process.stdout
+				stream: process.stdout
 			}]
 		}
 	}


### PR DESCRIPTION
Fixes crash on startup when using `NODE_ENV=production`


```
internal/fs/utils.js:453
    throw err;
    ^

TypeError [ERR_INVALID_ARG_TYPE]: The "path" argument must be one of type string, Buffer, or URL. Received type object
    at Object.open (fs.js:406:3)
    at WriteStream.open (internal/fs/streams.js:268:12)
    at new WriteStream (internal/fs/streams.js:255:10)
    at Object.createWriteStream (fs.js:1729:10)
    at Logger.addStream (/postcodes.io/node_modules/bunyan/lib/bunyan.js:592:27)
    at /postcodes.io/node_modules/bunyan/lib/bunyan.js:470:18
    at Array.forEach (<anonymous>)
    at new Logger (/postcodes.io/node_modules/bunyan/lib/bunyan.js:469:25)
    at new createLogger (/postcodes.io/node_modules/bunyan/lib/bunyan.js:1618:12)
    at Object.Logger.init (/postcodes.io/node_modules/commonlog-bunyan/index.js:12:18)
```
