### PR TITLE
Return 400 Error for invalid bulk inputs

### DIFF
--- a/app/models/postcode.js
+++ b/app/models/postcode.js
@@ -6,6 +6,7 @@ const { series } = require("async");
 const { Base, populateLocation, extractOnspdVal } = require("./base");
 const QueryStream = require("pg-query-stream");
 const { defaults } = require("../../config/config.js")();
+const { InvalidGeolocationError } = require("../lib/errors");
 
 const postcodeSchema = {
 	"id": "SERIAL PRIMARY KEY",
@@ -412,10 +413,10 @@ Postcode.prototype.nearestPostcodes = function (params, callback) {
 	if (limit > MAX_LIMIT) limit = MAX_LIMIT;
 
 	const longitude = parseFloat(params.longitude);
-	if (isNaN(longitude)) return callback(new Error("Invalid longitude"), null);
+	if (isNaN(longitude)) return callback(new InvalidGeolocationError(), null);
 
 	const latitude = parseFloat(params.latitude);
-	if (isNaN(latitude)) return callback(new Error("Invalid latitude"), null);
+	if (isNaN(latitude)) return callback(new InvalidGeolocationError(), null);
 
 	let radius = parseFloat(params.radius) || DEFAULT_RADIUS;
 	if (radius > MAX_RADIUS) radius = MAX_RADIUS;

--- a/test/postcode.unit.js
+++ b/test/postcode.unit.js
@@ -498,7 +498,7 @@ describe("Postcode Model", function () {
 			};
 			Postcode.nearestPostcodes(params, (error, postcodes) => {
 				assert.isNotNull(error);
-				assert.match(error.message, /invalid longitude/i);
+				assert.match(error.message, /Invalid longitude\/latitude submitted/i);
 				done();
 			});
 		});
@@ -509,7 +509,7 @@ describe("Postcode Model", function () {
 			};
 			Postcode.nearestPostcodes(params, (error, postcodes) => {
 				assert.isNotNull(error);
-				assert.match(error.message, /invalid latitude/i);
+				assert.match(error.message, /Invalid longitude\/latitude submitted/i);
 				done();
 			});
 		});

--- a/test/postcodes.bulk.integration.js
+++ b/test/postcodes.bulk.integration.js
@@ -246,7 +246,7 @@ describe("Postcodes routes", () => {
         .expect("Content-Type", /json/)
         .expect(helper.allowsCORS)
         .expect(400)
-        .end((err, response) => {
+        .end((error, response) => {
           if(error) return done(error)
           assert.match(response.body.error, /Invalid longitude\/latitude submitted/i);
           done();
@@ -266,7 +266,7 @@ describe("Postcodes routes", () => {
         .expect("Content-Type", /json/)
         .expect(helper.allowsCORS)
         .expect(400)
-        .end((err, response) => {
+        .end((error, response) => {
           if(error) return done(error)
           assert.match(response.body.error, /Invalid longitude\/latitude submitted/i);
           done();

--- a/test/postcodes.bulk.integration.js
+++ b/test/postcodes.bulk.integration.js
@@ -232,6 +232,46 @@ describe("Postcodes routes", () => {
             done();
           });
       });
+
+      it("should return 400 if type of value associated with latitude key is invalid", done => {
+        const invalidTestLocation = {
+          longitude: -2.12659411941741,
+          latitude: null,
+          widesearch: true,
+        };
+
+        request(app)
+        .post("/postcodes")
+        .send({geolocations: [invalidTestLocation]})
+        .expect("Content-Type", /json/)
+        .expect(helper.allowsCORS)
+        .expect(400)
+        .end((err, response) => {
+          if(error) return done(error)
+          assert.match(response.body.error, /Invalid longitude\/latitude submitted/i);
+          done();
+        })
+      });
+
+      it("should return 400 if type of value associated with longitude key is invalid", done => {
+        const invalidTestLocation = {
+          longitude: null,
+          latitude: 53.5351312861402,
+          widesearch: true,
+        };
+
+        request(app)
+        .post("/postcodes")
+        .send({geolocations: [invalidTestLocation]})
+        .expect("Content-Type", /json/)
+        .expect(helper.allowsCORS)
+        .expect(400)
+        .end((err, response) => {
+          if(error) return done(error)
+          assert.match(response.body.error, /Invalid longitude\/latitude submitted/i);
+          done();
+        })
+      });
     });
 
     describe("Bulk postcode lookup", () => {


### PR DESCRIPTION
Hey,

this PR changes error thrown in Postcode.nearestPostcodes from generic Error to InvalidGeolocationError.

