### PR TITLE
Check for postcodes that exist but aren't Scottish on the SPD endpoint

### DIFF
--- a/app/controllers/scottish_postcodes_controller.js
+++ b/app/controllers/scottish_postcodes_controller.js
@@ -6,7 +6,7 @@ const Pc = require("postcode");
 const {
   InvalidPostcodeError,
   PostcodeNotFoundError,
-  PostcodeNotScottishError,
+  PostcodeNotInSpdError,
 } = require("../lib/errors.js");
 
 exports.show = (request, response, next) => {
@@ -20,7 +20,7 @@ exports.show = (request, response, next) => {
       Postcode.find(postcode, (gerr, gres) => {
         if (gerr) return next(gerr);
         if (!gres) return next(new PostcodeNotFoundError());
-        return next(new PostcodeNotScottishError());
+        return next(new PostcodeNotInSpdError());
       });
     }
     response.jsonApiResponse = {

--- a/app/controllers/scottish_postcodes_controller.js
+++ b/app/controllers/scottish_postcodes_controller.js
@@ -1,20 +1,28 @@
 "use strict";
 
 const ScottishPostcode = require("../models/scottish_postcode");
-const Postcode = require("postcode");
+const Postcode = require("../models/postcode");
+const Pc = require("postcode");
 const {
   InvalidPostcodeError,
   PostcodeNotFoundError,
+  PostcodeNotScottishError,
 } = require("../lib/errors.js");
 
 exports.show = (request, response, next) => {
   const { postcode } = request.params;
-  if (!Postcode.isValid(postcode.trim()))
+  if (!Pc.isValid(postcode.trim()))
     return next(new InvalidPostcodeError());
 
   ScottishPostcode.find(postcode, (error, result) => {
     if (error) return next(error);
-    if (!result) return next(new PostcodeNotFoundError());
+    if (!result) {
+      Postcode.find(postcode, (gerr, gres) => {
+        if (gerr) return next(gerr);
+        if (!gres) return next(new PostcodeNotFoundError());
+        return next(new PostcodeNotScottishError());
+      });
+    }
     response.jsonApiResponse = {
       status: 200,
       result: ScottishPostcode.toJson(result),

--- a/app/controllers/scottish_postcodes_controller.js
+++ b/app/controllers/scottish_postcodes_controller.js
@@ -17,7 +17,9 @@ exports.show = (request, response, next) => {
   ScottishPostcode.find(postcode, (error, result) => {
     if (error) return next(error);
     if (!result) {
-      Postcode.find(postcode, (gerr, gres) => {
+      // The return value of Postcode.find is the return value of the callback
+      // see postcode.js lines 186-188
+      return Postcode.find(postcode, (gerr, gres) => {
         if (gerr) return next(gerr);
         if (!gres) return next(new PostcodeNotFoundError());
         return next(new PostcodeNotInSpdError());

--- a/app/lib/errors.js
+++ b/app/lib/errors.js
@@ -71,7 +71,7 @@ class PostcodeNotFoundError extends PostcodesioHttpError {
 
 class PostcodeNotInSpdError extends PostcodesioHttpError {
   constructor() {
-    super(404, "Postcode exists but not in SPD");
+    super(404, "Postcode exists in ONSPD but not in SPD");
   }
 }
 const INVALID_JSON_QUERY_MESSAGE = `Invalid JSON query submitted. 

--- a/app/lib/errors.js
+++ b/app/lib/errors.js
@@ -68,6 +68,12 @@ class PostcodeNotFoundError extends PostcodesioHttpError {
     super(404, "Postcode not found");
   }
 }
+
+class PostcodeNotScottishError extends PostcodesioHttpError {
+  constructor() {
+    super(404, "Postcode exists but is not Scottish");
+  }
+}
 const INVALID_JSON_QUERY_MESSAGE = `Invalid JSON query submitted. 
 You need to submit a JSON object with an array of postcodes or geolocation objects.
 Also ensure that Content-Type is set to application/json
@@ -156,6 +162,7 @@ class OutcodeNotFoundError extends PostcodesioHttpError {
 
 module.exports = {
   PostcodesioHttpError,
+  PostcodeNotScottishError,
   InvalidJsonError,
   NotFoundError,
   InvalidPostcodeError,

--- a/app/lib/errors.js
+++ b/app/lib/errors.js
@@ -71,7 +71,7 @@ class PostcodeNotFoundError extends PostcodesioHttpError {
 
 class PostcodeNotScottishError extends PostcodesioHttpError {
   constructor() {
-    super(404, "Postcode exists but is not Scottish");
+    super(404, "Postcode exists but not in SPD");
   }
 }
 const INVALID_JSON_QUERY_MESSAGE = `Invalid JSON query submitted. 
@@ -162,11 +162,11 @@ class OutcodeNotFoundError extends PostcodesioHttpError {
 
 module.exports = {
   PostcodesioHttpError,
-  PostcodeNotScottishError,
   InvalidJsonError,
   NotFoundError,
   InvalidPostcodeError,
   PostcodeNotFoundError,
+  PostcodeNotScottishError,
   InvalidJsonQueryError,
   JsonArrayRequiredError,
   ExceedMaxGeolocationsError,

--- a/app/lib/errors.js
+++ b/app/lib/errors.js
@@ -69,7 +69,7 @@ class PostcodeNotFoundError extends PostcodesioHttpError {
   }
 }
 
-class PostcodeNotScottishError extends PostcodesioHttpError {
+class PostcodeNotInSpdError extends PostcodesioHttpError {
   constructor() {
     super(404, "Postcode exists but not in SPD");
   }
@@ -166,7 +166,7 @@ module.exports = {
   NotFoundError,
   InvalidPostcodeError,
   PostcodeNotFoundError,
-  PostcodeNotScottishError,
+  PostcodeNotInSpdError,
   InvalidJsonQueryError,
   JsonArrayRequiredError,
   ExceedMaxGeolocationsError,

--- a/test/scottish_postcodes.integration.js
+++ b/test/scottish_postcodes.integration.js
@@ -112,5 +112,23 @@ describe("Scottish postcode route", () => {
           done();
         });
     });
+
+    it("should return error if postcode not found but is found in main database", done => {
+      const postcode = "SW1A0AA";
+      const path = `/scotland/postcodes/${encodeURI(postcode)}`;
+      request(app)
+        .get(path)
+        .expect("Content-Type", /json/)
+        .expect(404)
+        .end((error, response) => {
+          if (error) return done(error);
+          assert.property(response.body, "status");
+          assert.equal(response.body.status, 404);
+          assert.property(response.body, "error");
+          assert.equal(Object.keys(response.body).length, 2);
+          assert.equal(response.body.error, "Postcode exists but is not Scottish");
+          done();
+        });
+    });
   });
 });

--- a/test/scottish_postcodes.integration.js
+++ b/test/scottish_postcodes.integration.js
@@ -126,7 +126,7 @@ describe("Scottish postcode route", () => {
           assert.equal(response.body.status, 404);
           assert.property(response.body, "error");
           assert.equal(Object.keys(response.body).length, 2);
-          assert.equal(response.body.error, "Postcode exists but is not Scottish");
+          assert.equal(response.body.error, "Postcode exists but not in SPD");
           done();
         });
     });

--- a/test/scottish_postcodes.integration.js
+++ b/test/scottish_postcodes.integration.js
@@ -114,7 +114,7 @@ describe("Scottish postcode route", () => {
     });
 
     it("should return error if postcode not found but is found in main database", done => {
-      const postcode = "SW1A0AA";
+      const postcode = "M11AD";
       const path = `/scotland/postcodes/${encodeURI(postcode)}`;
       request(app)
         .get(path)
@@ -126,7 +126,7 @@ describe("Scottish postcode route", () => {
           assert.equal(response.body.status, 404);
           assert.property(response.body, "error");
           assert.equal(Object.keys(response.body).length, 2);
-          assert.equal(response.body.error, "Postcode exists but not in SPD");
+          assert.equal(response.body.error, "Postcode exists in ONSPD but not in SPD");
           done();
         });
     });


### PR DESCRIPTION
This fixes #388 - response would now still be a 404, but have error `Postcode exists but not in SPD` if a postcode is looked up that is valid, but not in the Scottish database.