### PR TITLE
Remove unused link from /about page

### DIFF
--- a/app/views/about/content.ejs
+++ b/app/views/about/content.ejs
@@ -40,7 +40,6 @@
       <p>
         <a href="https://github.com/previousdeveloper/PythonPostcodesWrapper">PythonPostcodesWrapper</a> by <a href="https://github.com/previousdeveloper">Gokhan Karadas</a><br>
         <a href="https://github.com/raigad/python-postcodes-io">postcodes_io_api</a> by <a href="https://github.com/raigad">Rohit Deshmukh</a> (<a href="https://pypi.org/project/postcodes-io-api/">Python Package</a>)
-        <a href="https://github.com/raigad/python-postcodes-io"></a>
       </p>
       <p>
         <strong>C&#35;</strong>


### PR DESCRIPTION
Duplicate link for Python project