### PR TITLE
fixed ENV mismatch in docker-compose.yml

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,7 +6,7 @@ services:
     depends_on:
       - db
     environment:
-      - POSTGRES_DB=postcodesiodb
+      - POSTGRES_DATABASE=postcodesiodb
       - POSTGRES_PASSWORD=secret
       - POSTGRES_USER=postcodesio
       - POSTGRES_HOST=db


### PR DESCRIPTION
Noticed when deploying these to Azure that the DB name was always the default of `postcodesiodb` no matter what i set `POSTGRES_DB` to. then noticed that the ENV var inside `config/config.js` is looking for `POSTGRES_DATABASE` 

updated the compose file to match.