### PR TITLE
[WIP] fix(SPD): Correct and ingest invalid SPD postcodes

### DIFF
--- a/latest
+++ b/latest
@@ -1,1 +1,1 @@
-https://postcodesio.s3.amazonaws.com/public/postcodesio-2020-12-08-2035.sql.gz
+https://postcodesio.s3.amazonaws.com/public/postcodesio-2020-12-17-1320.sql.gz

--- a/test/scottish_postcode.unit.ts
+++ b/test/scottish_postcode.unit.ts
@@ -57,6 +57,11 @@ describe("Scottish Postcode Model", () => {
         const result = await query(q);
         assert.isTrue(result.rows[0].count > 0);
       });
+
+      it("loads postcodes suffixed with additional character", async () => {
+        const result = await ScottishPostcode.find("PA31 8UA");
+        assert.isNotNull(result);
+      });
     });
   });
 


### PR DESCRIPTION
Reintroduces fix from #578

Some postcodes on SPD have an extra character appended. Since these are
picked up as invalid postcodes, they can no longer be queried

This change will ingest the first instance of these invalid postcodes
(i.e. those ending with A) and drop all others