### PR TITLE
Add parliamentary_constituency array to outcode queries

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,4 @@ npm-debug.log
 *.swp
 *.vim
 dist
+coverage

--- a/src/app/models/outcode.ts
+++ b/src/app/models/outcode.ts
@@ -42,7 +42,7 @@ const relation = {
     admin_county: "VARCHAR(255)[]",
     admin_ward: "VARCHAR(255)[]",
     country: "VARCHAR(255)[]",
-    parliamentary_constituency: "VARCHAR(255)[]"
+    parliamentary_constituency: "VARCHAR(255)[]",
   },
   indexes: [
     {

--- a/src/app/models/outcode.ts
+++ b/src/app/models/outcode.ts
@@ -24,6 +24,7 @@ export interface OutcodeInterface {
   admin_county: string[];
   admin_ward: string[];
   country: string[];
+  parliamentary_constituency: string[];
 }
 
 const relation = {
@@ -41,6 +42,7 @@ const relation = {
     admin_county: "VARCHAR(255)[]",
     admin_ward: "VARCHAR(255)[]",
     country: "VARCHAR(255)[]",
+    parliamentary_constituency: "VARCHAR(255)[]"
   },
   indexes: [
     {
@@ -101,6 +103,7 @@ const toJson = (o: OutcodeTuple): OutcodeInterface => {
     admin_county: o.admin_county,
     admin_ward: o.admin_ward,
     country: o.country,
+    parliamentary_constituency: o.parliamentary_constituency,
   };
 };
 

--- a/src/app/models/postcode.ts
+++ b/src/app/models/postcode.ts
@@ -687,6 +687,19 @@ attributesQuery.push(`
 	) as country
 `);
 
+attributesQuery.push(`
+	array(
+		SELECT
+			DISTINCT constituencies.name
+		FROM
+			postcodes
+    LEFT OUTER JOIN
+      constituencies ON postcodes.constituency_id = constituencies.code
+		WHERE
+			outcode=$1 AND constituencies.name IS NOT NULL
+	) as parliamentary_constituency
+`);
+
 const outcodeQuery = `
 	SELECT
 		outcode, avg(northings) as northings, avg(eastings) as eastings,
@@ -706,6 +719,7 @@ const outcodeAttributes = [
   "parish",
   "admin_county",
   "admin_ward",
+  "parliamentary_constituency",
 ];
 
 const toArray = (i: string[] | [null]) => {
@@ -724,6 +738,7 @@ interface OutcodeTupleOutput {
   admin_county: string[] | [null];
   admin_ward: string[] | [null];
   country: string[] | [null];
+  parliamentary_constituency: string[] | [null];
 }
 
 const findOutcode = async (o: string): Promise<OutcodeInterface | null> => {
@@ -739,6 +754,7 @@ const findOutcode = async (o: string): Promise<OutcodeInterface | null> => {
   result.parish = toArray(result.parish);
   result.admin_ward = toArray(result.admin_ward);
   result.country = toArray(result.country);
+  result.parliamentary_constituency = toArray(result.parliamentary_constituency);
   return result;
 };
 

--- a/test/outcode.unit.ts
+++ b/test/outcode.unit.ts
@@ -37,6 +37,7 @@ describe("Outcode Model", () => {
         parish: [],
         admin_county: [],
         admin_ward: ["Torry/Ferryhill"],
+        parliamentary_constituency: ["Aberdeen North"],
       };
       await Outcode.create(record);
       await Outcode.populateLocation();
@@ -55,6 +56,7 @@ describe("Outcode Model", () => {
         parish: [],
         admin_county: [],
         admin_ward: ["Torry/Ferryhill"],
+        parliamentary_constituency: ["Aberdeen North"],
       };
       await Outcode.create(record);
       await Outcode.populateLocation();

--- a/test/postcode.unit.ts
+++ b/test/postcode.unit.ts
@@ -245,6 +245,7 @@ describe("Postcode Model", function () {
       assert.isArray(result["admin_county"]);
       assert.isArray(result["parish"]);
       assert.isArray(result["country"]);
+      assert.isArray(result["parliamentary_constituency"]);
     });
     it("should return null if no matching outcode", async () => {
       const result = await Postcode.findOutcode("EZ12");


### PR DESCRIPTION
Just a little MR so that the outcode response is more complete. I saw that they already had arrays of wards and districts so I thought it made sense for pcons to also be returned.

(Also added the coverage folder to gitignore).