### PR TITLE
Made it so the search for places always do a prefixsearch instead

### DIFF
--- a/src/app/controllers/places_controller.ts
+++ b/src/app/controllers/places_controller.ts
@@ -51,7 +51,7 @@ const searchPlace: Handler = async (request, response, next) => {
     //if NAN make it undefined
     if (isNaN(limit)) limit = undefined;
 
-    const places = await Place.search({ name, limit });
+    const places = await Place.prefixSearch({ name, limit });
     if (!places) return returnEmptyResponse(response, next);
     response.jsonApiResponse = {
       status: 200,


### PR DESCRIPTION
This prevents results missing, E.G search for lough with the normal search and you only get Beacon Lough and not loughborogh