### PR TITLE
feat: add optional posthog monitoring

### DIFF
--- a/api/app.ts
+++ b/api/app.ts
@@ -3,6 +3,7 @@ import { Config } from "./config/config";
 import logger from "./config/logger";
 import { expressConfig } from "./config/express";
 import { prometheusConfig } from "./config/prometheus";
+import { posthogConfig } from "./config/posthog";
 import { routes } from "./config/routes";
 import { rendererConfig } from "./config/renderer";
 
@@ -11,6 +12,7 @@ export default (config: Config): express.Express => {
   logger(app, config);
   expressConfig(app, config);
   prometheusConfig(app, config);
+  posthogConfig(app, config);
   routes(app);
   rendererConfig(app);
   return app;

--- a/api/config/README.md
+++ b/api/config/README.md
@@ -40,6 +40,11 @@ GA_KEY
 PROMETHEUS_USERNAME
 PROMETHEUS_PASSWORD
 
+# Inserts optional PostHog monitoring middleware
+# Captures an `api_request` event per request (normalized path, method, status, duration)
+POSTHOG_API_KEY # PostHog project API key. Monitoring is disabled if unset
+POSTHOG_HOST # Optional PostHog instance host, e.g. https://eu.i.posthog.com
+
 # Application defaults configuration
 NEAREST_RADIUS_DEFAULT       # /postcodes?lon=&lat= radius default (metres, default 100)
 NEAREST_RADIUS_MAX           # /postcodes?lon=&lat= radius cap (metres, default 2000)

--- a/api/config/config.ts
+++ b/api/config/config.ts
@@ -46,6 +46,8 @@ export interface Config {
   httpHeaders?: Record<string, string>;
   prometheusUsername?: string;
   prometheusPassword?: string;
+  posthogApiKey?: string;
+  posthogHost?: string;
 }
 
 const config: Record<Env, Config> = {
@@ -125,6 +127,8 @@ export const getConfig = (env?: Env): Config => {
     LOG_DESTINATION,
     PROMETHEUS_USERNAME,
     PROMETHEUS_PASSWORD,
+    POSTHOG_API_KEY,
+    POSTHOG_HOST,
     HTTP_HEADERS,
     URL_PREFIX,
   } = process.env;
@@ -150,6 +154,9 @@ export const getConfig = (env?: Env): Config => {
     cfg.prometheusUsername = PROMETHEUS_USERNAME;
   if (PROMETHEUS_PASSWORD !== undefined)
     cfg.prometheusPassword = PROMETHEUS_PASSWORD;
+
+  if (POSTHOG_API_KEY !== undefined) cfg.posthogApiKey = POSTHOG_API_KEY;
+  if (POSTHOG_HOST !== undefined) cfg.posthogHost = POSTHOG_HOST;
 
   if (URL_PREFIX !== undefined) cfg.urlPrefix = URL_PREFIX;
 

--- a/api/config/posthog.ts
+++ b/api/config/posthog.ts
@@ -1,0 +1,57 @@
+import { PostHog } from "posthog-node";
+import { Express } from "express";
+import { Config } from "./config";
+import { normalizePath } from "./prometheus";
+
+let client: PostHog | undefined;
+
+/**
+ * Inserts optional PostHog monitoring middleware
+ *
+ * Captures an `api_request` event per request with the normalized path
+ * (e.g. /postcodes/:postcode), method, status code and duration
+ *
+ * Enabled by defining:
+ * - POSTHOG_API_KEY
+ * - POSTHOG_HOST (optional, e.g. https://eu.i.posthog.com)
+ */
+export const posthogConfig = (
+  app: Express,
+  { posthogApiKey, posthogHost }: Config
+): void => {
+  if (posthogApiKey === undefined) return;
+
+  client = new PostHog(posthogApiKey, {
+    host: posthogHost,
+  });
+  // Never let telemetry failures surface in the API
+  client.on("error", () => {});
+
+  app.use((request, response, next) => {
+    const start = process.hrtime.bigint();
+    response.on("finish", () => {
+      const duration = Number(process.hrtime.bigint() - start) / 1e6;
+      client?.capture({
+        distinctId: request.ip || "unknown",
+        event: "api_request",
+        properties: {
+          method: request.method,
+          path: normalizePath(request),
+          status: response.statusCode,
+          duration_ms: Math.round(duration * 100) / 100,
+          $process_person_profile: false,
+        },
+      });
+    });
+    next();
+  });
+};
+
+/**
+ * Flushes queued events and closes the PostHog client
+ */
+export const shutdownPosthog = async (): Promise<void> => {
+  if (client === undefined) return;
+  await client.shutdown();
+  client = undefined;
+};

--- a/api/config/prometheus.ts
+++ b/api/config/prometheus.ts
@@ -30,7 +30,7 @@ const paths: [RegExp, string][] = [
  *
  * e.g. /postcodes/sw1a2aa -> /postcodes/:postcode
  */
-const normalizePath = (request: Request): string => {
+export const normalizePath = (request: Request): string => {
   for (const [regex, path] of paths) {
     if (regex.test(request.path)) return path;
   }

--- a/api/server.ts
+++ b/api/server.ts
@@ -3,6 +3,7 @@ const config = getConfig();
 import App from "./app";
 const app = App(config);
 import { logger } from "./app/lib/logger";
+import { shutdownPosthog } from "./config/posthog";
 const { host } = config;
 const { port } = config;
 
@@ -14,8 +15,9 @@ const closeSocket = (_: unknown, socket: any) => {
 server.on("clientError", closeSocket);
 server.on("connect", closeSocket);
 
-process.on("SIGTERM", () => {
+process.on("SIGTERM", async () => {
   logger.info("Quitting Postcode API");
+  await shutdownPosthog();
   process.exit(0);
 });
 

--- a/package.json
+++ b/package.json
@@ -55,6 +55,7 @@
     "pg": "~8.16.3",
     "pino": "~10.3.1",
     "postcode": "~5.1.0",
+    "posthog-node": "~5.46.1",
     "prom-client": "~15.1.3",
     "serve-favicon": "~2.5.1"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -45,6 +45,9 @@ importers:
       postcode:
         specifier: ~5.1.0
         version: 5.1.0
+      posthog-node:
+        specifier: ~5.46.1
+        version: 5.46.1
       prom-client:
         specifier: ~15.1.3
         version: 15.1.3
@@ -1980,6 +1983,12 @@ packages:
 
   '@polka/url@1.0.0-next.29':
     resolution: {integrity: sha512-wwQAWhWSuHaag8c4q/KN/vCoeOJYshAIvMQwD4GpSb3OiZklFfvAgmj0VCBBImRpuF/aFgIRzllXlVX93Jevww==}
+
+  '@posthog/core@1.45.1':
+    resolution: {integrity: sha512-tLtvzomavb2PPWdGYKsusyIzIeL2Px47v348Smibkay7sMy/83TyPk+Ptsp2NdeOgJsbuwSxWkR2+XA0aSCAaA==}
+
+  '@posthog/types@1.398.0':
+    resolution: {integrity: sha512-sJMkl4k+u8yS/0fjHsKqE9xTdsAh30a2WvgChiptellnVoE0e8QJKFgqOMD2sk8FaEArPdeFklAhXvmENAt3Sg==}
 
   '@protobufjs/aspromise@1.1.2':
     resolution: {integrity: sha512-j+gKExEuLmKwvz3OgROXtrJ2UG2x8Ch2YZUxahh+s1F2HZ+wAceUNLkvy6zKCPVRkU++ZWQrdxsUeQXmcg4uoQ==}
@@ -6586,6 +6595,15 @@ packages:
     resolution: {integrity: sha512-9ZhXKM/rw350N1ovuWHbGxnGh/SNJ4cnxHiM0rxE4VN41wsg8P8zWn9hv/buK00RP4WvlOyr/RBDiptyxVbkZQ==}
     engines: {node: '>=0.10.0'}
 
+  posthog-node@5.46.1:
+    resolution: {integrity: sha512-WjCqExq44pBdyg9MSsH6UAE0tNZ88p4aIuVFicgqhjf2Fbws6IhS4ioYUa4aBrbUPS9EDRXtBTtF5DpP1ml8Pw==}
+    engines: {node: ^20.20.0 || >=22.22.0}
+    peerDependencies:
+      rxjs: ^7.0.0
+    peerDependenciesMeta:
+      rxjs:
+        optional: true
+
   postman-code-generators@1.14.2:
     resolution: {integrity: sha512-qZAyyowfQAFE4MSCu2KtMGGQE/+oG1JhMZMJNMdZHYCSfQiVVeKxgk3oI4+KJ3d1y5rrm2D6C6x+Z+7iyqm+fA==}
     engines: {node: '>=12'}
@@ -11152,6 +11170,12 @@ snapshots:
       config-chain: 1.1.13
 
   '@polka/url@1.0.0-next.29': {}
+
+  '@posthog/core@1.45.1':
+    dependencies:
+      '@posthog/types': 1.398.0
+
+  '@posthog/types@1.398.0': {}
 
   '@protobufjs/aspromise@1.1.2': {}
 
@@ -16487,6 +16511,10 @@ snapshots:
   postgres-interval@1.2.0:
     dependencies:
       xtend: 4.0.2
+
+  posthog-node@5.46.1:
+    dependencies:
+      '@posthog/core': 1.45.1
 
   postman-code-generators@1.14.2:
     dependencies:

--- a/test/posthog.integration.ts
+++ b/test/posthog.integration.ts
@@ -1,0 +1,74 @@
+import { describe, expect, it, vi, beforeEach } from "vitest";
+import request from "supertest";
+import { config, postcodesioApplication } from "./helper";
+
+const capture = vi.fn();
+const shutdown = vi.fn();
+
+vi.mock("posthog-node", () => ({
+  PostHog: vi.fn(function (this: any) {
+    this.capture = capture;
+    this.shutdown = shutdown;
+    this.on = vi.fn();
+  }),
+}));
+
+import { PostHog } from "posthog-node";
+import { shutdownPosthog } from "../api/config/posthog";
+
+describe("PostHog monitoring", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe("when no API key is provided", () => {
+    it("does not instantiate a client or capture events", async () => {
+      const app = postcodesioApplication({ ...config });
+      await request(app).get("/postcodes/foobar");
+      expect(PostHog).not.toHaveBeenCalled();
+      expect(capture).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("when an API key is provided", () => {
+    const posthogApiKey = "phc_test";
+    const posthogHost = "https://eu.i.posthog.com";
+
+    const application = () =>
+      postcodesioApplication({ ...config, posthogApiKey, posthogHost });
+
+    it("instantiates a client with key and host", () => {
+      application();
+      expect(PostHog).toHaveBeenCalledWith(posthogApiKey, {
+        host: posthogHost,
+      });
+    });
+
+    it("captures an event with normalized path", async () => {
+      const app = application();
+      await request(app).get("/postcodes/foobar");
+      expect(capture).toHaveBeenCalledTimes(1);
+      const event = capture.mock.calls[0][0];
+      expect(event.event).toBe("api_request");
+      expect(event.properties.path).toBe("/postcodes/:postcode");
+      expect(event.properties.method).toBe("GET");
+      expect(event.properties.status).toBe(404);
+      expect(event.properties.duration_ms).toBeTypeOf("number");
+      expect(event.properties.$process_person_profile).toBe(false);
+      expect(event.distinctId).toBeTypeOf("string");
+    });
+
+    it("squashes unexpected paths to other", async () => {
+      const app = application();
+      await request(app).get("/bogus");
+      expect(capture).toHaveBeenCalledTimes(1);
+      expect(capture.mock.calls[0][0].properties.path).toBe("other");
+    });
+
+    it("flushes the client on shutdown", async () => {
+      application();
+      await shutdownPosthog();
+      expect(shutdown).toHaveBeenCalled();
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- Adds optional PostHog monitoring middleware, enabled by `POSTHOG_API_KEY` (and optional `POSTHOG_HOST`); disabled entirely when unset, mirroring the optional Prometheus setup
- Captures one anonymous `api_request` event per request with normalized path (e.g. `/postcodes/:postcode`), method, status and duration - reuses the Prometheus `normalizePath` so raw URLs (queried postcodes) stay out of analytics and event cardinality stays low
- Telemetry failures are swallowed so they never surface in API responses; SIGTERM flushes buffered events before exit

## Test plan
- `pnpm test test/posthog.integration.ts` - covers no-op without key, client construction, event shape, path normalisation and shutdown flush
- `pnpm build`
- Manual: set `POSTHOG_API_KEY` + `POSTHOG_HOST`, start the server, hit `/postcodes/foo` and confirm an `api_request` event arrives in PostHog

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ideal-postcodes/codesmith/postcodes.io/pr/1386"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787472031&installation_model_id=3790&pr_number=1386&repository=ideal-postcodes%2Fpostcodes.io&return_to=https%3A%2F%2Fgithub.com%2Fideal-postcodes%2Fpostcodes.io%2Fpull%2F1386&signature=110af6847fbbfb50ae8dc389d8dd2d5760124e68be5ac6290bb1f1d652a91b8f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->