### PR TITLE
chore(docs): add optional posthog monitoring to website

### DIFF
--- a/docusaurus.config.ts
+++ b/docusaurus.config.ts
@@ -179,6 +179,19 @@ const config: Config = {
   } satisfies Preset.ThemeConfig,
 
   plugins: [
+    // Optional PostHog monitoring, enabled at build time by POSTHOG_API_KEY
+    ...(process.env.POSTHOG_API_KEY
+      ? [
+          [
+            "posthog-docusaurus",
+            {
+              apiKey: process.env.POSTHOG_API_KEY,
+              appUrl: process.env.POSTHOG_HOST || "https://eu.i.posthog.com",
+              enableInDevelopment: false,
+            },
+          ],
+        ]
+      : []),
     [
       "docusaurus-plugin-openapi-docs",
       {

--- a/package.json
+++ b/package.json
@@ -92,6 +92,7 @@
     "openapi-types": "~12.1.3",
     "path": "~0.12.7",
     "path-browserify": "~1.0.1",
+    "posthog-docusaurus": "~2.0.5",
     "prettier": "~3.8.3",
     "prism-react-renderer": "~2.4.1",
     "process": "~0.11.10",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -151,6 +151,9 @@ importers:
       path-browserify:
         specifier: ~1.0.1
         version: 1.0.1
+      posthog-docusaurus:
+        specifier: ~2.0.5
+        version: 2.0.5
       prettier:
         specifier: ~3.8.3
         version: 3.8.3
@@ -6585,6 +6588,10 @@ packages:
   postgres-interval@1.2.0:
     resolution: {integrity: sha512-9ZhXKM/rw350N1ovuWHbGxnGh/SNJ4cnxHiM0rxE4VN41wsg8P8zWn9hv/buK00RP4WvlOyr/RBDiptyxVbkZQ==}
     engines: {node: '>=0.10.0'}
+
+  posthog-docusaurus@2.0.5:
+    resolution: {integrity: sha512-Ray65LYEJrMMqDtsBUBXunEVP/g4wtATvq/xz9rchUoLy/9mSkkFgUko/8DVtGxgiP3vivpFMgfb9HpCuDrBHg==}
+    engines: {node: '>=10.15.1'}
 
   postman-code-generators@1.14.2:
     resolution: {integrity: sha512-qZAyyowfQAFE4MSCu2KtMGGQE/+oG1JhMZMJNMdZHYCSfQiVVeKxgk3oI4+KJ3d1y5rrm2D6C6x+Z+7iyqm+fA==}
@@ -16487,6 +16494,8 @@ snapshots:
   postgres-interval@1.2.0:
     dependencies:
       xtend: 4.0.2
+
+  posthog-docusaurus@2.0.5: {}
 
   postman-code-generators@1.14.2:
     dependencies:


### PR DESCRIPTION
## Summary
- Adds optional frontend PostHog monitoring to the Docusaurus website via the official `posthog-docusaurus` plugin (autocapture + pageviews)
- Enabled at build time by `POSTHOG_API_KEY` (plus optional `POSTHOG_HOST`, defaulting to `https://eu.i.posthog.com`); when unset the plugin is not loaded and no posthog code appears in the built site
- No server/API changes

## Test plan
- `POSTHOG_API_KEY=phc_test pnpm docs:build` then `grep -r phc_test build/index.html` - snippet present
- `pnpm docs:build` without the key - `grep -ri posthog build/index.html` finds nothing

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ideal-postcodes/codesmith/postcodes.io/pr/1387"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787731085&installation_model_id=3790&pr_number=1387&repository=ideal-postcodes%2Fpostcodes.io&return_to=https%3A%2F%2Fgithub.com%2Fideal-postcodes%2Fpostcodes.io%2Fpull%2F1387&signature=57d8589ac4700bcae0cc35d5016c2c52c860c84883232d6ebf7d834b7085270c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->